### PR TITLE
Upgrading to Realtidsinformation v4

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,5 @@
+# v1.0.4 / 2017-02-26
+- Fix: Switched from Realtidsinformation v3 to v4
 
 # v1.0.3 / 2015-06-01
 - Fix: Added lodash as dependency

--- a/lib/services/RealtimeInformation.coffee
+++ b/lib/services/RealtimeInformation.coffee
@@ -4,9 +4,9 @@ Base = require './Base'
 class RealtimeInformation extends Base
   constructor: (config) ->
     @key = config.keys.realtimeInformation
-    @service = 'realtimeInformation (SL Realtidsinformation 3)'
+    @service = 'realtimeInformation (SL Realtidsinformation 4)'
     super
 
 module.exports = (args...) ->
   service = new RealtimeInformation args...
-  (args...) -> service.prepareRequest "realtimedepartures", args...
+  (args...) -> service.prepareRequest "realtimedeparturesV4", args...

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "test": "mocha --compilers coffee:coffee-script/register -R spec",
     "example": "npm run-script compile && node example/index.js",
     "precommit": "npm test",
-    "prepush": "npm test"
+    "prepush": "npm test",
+    "prepublish": "npm compile"
   }
 }

--- a/package.json
+++ b/package.json
@@ -67,6 +67,6 @@
     "example": "npm run-script compile && node example/index.js",
     "precommit": "npm test",
     "prepush": "npm test",
-    "prepublish": "npm compile"
+    "prepublish": "npm run compile"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sl-api",
   "description": "Wrapper for Storstockholms Lokaltrafiks (SL) public API:s",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": {
     "name": "Simon Johansson",
     "email": "mail@simon-johansson.com"

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -65,7 +65,7 @@ describe 'SL (Storstockholms Lokaltrafik) API Wrapper\n', ()->
       it 'should make request to realtimedepartures endpoint', (done) ->
         new SL(keys).realtimeInformation (err, data) ->
           url = request.get.args[0][0].url
-          expect(url).to.eql 'http://api.sl.se/api2/realtimedepartures.json?key=xxx'
+          expect(url).to.eql 'http://api.sl.se/api2/realtimedeparturesV4.json?key=xxx'
           done()
 
       it 'should return the response with right formatting', (done) ->


### PR DESCRIPTION
A new API for Real Time information has been published and the v3 API will stop working from April 20th 2017. 

This PR includes the switch to the new API.