### PR TITLE
Moving the RealtimeInformation interface to use API version 4.

### DIFF
--- a/lib/services/RealtimeInformation.coffee
+++ b/lib/services/RealtimeInformation.coffee
@@ -4,9 +4,9 @@ Base = require './Base'
 class RealtimeInformation extends Base
   constructor: (config) ->
     @key = config.keys.realtimeInformation
-    @service = 'realtimeInformation (SL Realtidsinformation 3)'
+    @service = 'realtimeInformation (SL Realtidsinformation 4)'
     super
 
 module.exports = (args...) ->
   service = new RealtimeInformation args...
-  (args...) -> service.prepareRequest "realtimedepartures", args...
+  (args...) -> service.prepareRequest "realtimedeparturesV4", args...

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -65,7 +65,7 @@ describe 'SL (Storstockholms Lokaltrafik) API Wrapper\n', ()->
       it 'should make request to realtimedepartures endpoint', (done) ->
         new SL(keys).realtimeInformation (err, data) ->
           url = request.get.args[0][0].url
-          expect(url).to.eql 'http://api.sl.se/api2/realtimedepartures.json?key=xxx'
+          expect(url).to.eql 'http://api.sl.se/api2/realtimedeparturesV4.json?key=xxx'
           done()
 
       it 'should return the response with right formatting', (done) ->


### PR DESCRIPTION
We have updated the RealtimeInformation service to use the updated url for SL Realtidsinformation version 4. 
The url now have the form:
`http://api.sl.se/api2/realtimedeparturesV4.<FORMAT>?key=<DIN API NYCKEL>&siteid=<SITEID>&timewindow=<TIMEWINDOW>`